### PR TITLE
fix(auth): refuse to mint tokens when ECAN_JWT_SECRET is unconfigured

### DIFF
--- a/cloudbase-graphql/.env.example
+++ b/cloudbase-graphql/.env.example
@@ -1,30 +1,53 @@
 # ============================================================
 # eCan.ai CN 版本 — 环境变量模板
 # 复制此文件为 .env.local，填入真实值
+#
+# 敏感度图例 (按字段分类，对应 .env.local 真实值):
+#   🔒 SECRET    — 不可公开。泄露 = 直接攻击面
+#                   (DB 接管 / token 伪造 / 推送伪造)
+#   🟡 INTERNAL  — 半公开。泄露基础设施元数据，建议保持私有
+#   ✅ PUBLIC    — 可公开。可放 .env.example 或客户端代码
+#
+# deploy-ws-tcs.sh / sync-tcb-env 会把 .env.local 中的真值通过
+# TCB API 注入到容器 / 函数 EnvParams，密钥不会进 git 也不会进镜像。
 # ============================================================
 
 # ── PostgreSQL ──────────────────────────────────────────────
-# DATABASE_URL=postgresql://user:password@host:5432/dbname
+# 🔒 SECRET — 含 DB 用户名/密码 + 内网 IP + 实例 ID + VPC 元数据
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/dbname
 
 # ── TCB ─────────────────────────────────────────────────────
-# TCB_ENV_ID=sccb0-xxxxxxxx
-# TCB_API_URL=https://sccb0-xxxxxxxx.service.tcloudbase.com/api/graphql
-# TCB_REGION=ap-shanghai
+# ✅ PUBLIC
+TCB_ENV_ID=sccb0-xxxxxxxx
+TCB_API_URL=https://sccb0-xxxxxxxx.service.tcloudbase.com/api/graphql
+TCB_REGION=ap-shanghai
 
 # ── COS 文件存储 ─────────────────────────────────────────────
-# COS_BUCKET=7363-sccb0-xxxxxxxx-1251680599
-# COS_REGION=ap-shanghai
+# ✅ PUBLIC
+COS_BUCKET=7363-sccb0-xxxxxxxx-1251680599
+COS_REGION=ap-shanghai
 
 # ── CN 云任务调度 ─────────────────────────────────────────────
-# TENCENT_SCHEDULER_FUNCTION=ecan-graphql-api
-# TENCENT_SCF_NAMESPACE=default
-# TENCENT_REGION=ap-shanghai
+# ✅ PUBLIC
+TENCENT_SCHEDULER_FUNCTION=ecan-graphql-api
+TENCENT_SCF_NAMESPACE=default
+TENCENT_REGION=ap-shanghai
 
 # ── WebSocket 服务 (TCS 云托管) ───────────────────────────────
-# WS_PUSH_SECRET=<generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))">
-# WS_TCS_URL=<部署后由 bin/deploy-ws 脚本自动写入>
+# 🔒 SECRET — SCF → WS 推送鉴权密钥
+# 生成: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# 必须与 TCS 容器 EnvParams.WS_PUSH_SECRET 一致
+WS_PUSH_SECRET=
+
+# 🟡 INTERNAL — TCB 内网域名 (部署后由 bin/deploy-ws 自动写入)
+WS_TCS_URL=
 
 # ── 开发开关 ─────────────────────────────────────────────────
-# 生产: false / 本地 dev: true
-# ALLOW_INSECURE_AUTH=false
-# NODE_ENV=production
+# ✅ PUBLIC
+NODE_ENV=production
+ALLOW_INSECURE_AUTH=false
+
+# 🔒 SECRET — 30-day session token HS256 signing secret
+# 生成: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# 必须同时存在于 ecan-graphql-api 函数 和 ecan-graphql-ws 容器
+ECAN_JWT_SECRET=

--- a/cloudbase-graphql/.env.local.example
+++ b/cloudbase-graphql/.env.local.example
@@ -1,38 +1,48 @@
 # ============================================================
-# eCan.ai CN 版本 - TCB 云函数配置
+# eCan.ai CN 版本 - TCB 云函数配置模板
+# 复制此文件为 .env.local 填入真实值
+#
+# 敏感度图例:
+#   🔒 SECRET    - 不可公开。泄露 = 直接攻击面
+#   🟡 INTERNAL  - 半公开。基础设施元数据
+#   ✅ PUBLIC    - 可公开
 # ============================================================
 
-# ============ PostgreSQL 连接信息 =============
+# ============ PostgreSQL 连接信息 🔒 =============
 # 从 TCB 云数据库 PostgreSQL 实例详情页获取
 # 格式: postgresql://user:password@host:5432/database
 DATABASE_URL=
 
-# ============ TCB 环境信息 ============
-TCB_ENV_ID=sccb0-d0gc5398xf028be6a
-TCB_API_URL=https://sccb0-d0gc5398xf028be6a.service.tcloudbase.com/api/graphql
+# ============ TCB 环境信息 ✅ =============
+TCB_ENV_ID=sccb0-xxxxxxxx
+TCB_API_URL=https://sccb0-xxxxxxxx.service.tcloudbase.com/api/graphql
 
-# ============ COS 用户文件存储 ============
+# ============ COS 用户文件存储 ✅ =============
 # Bucket 名称格式: bucket-name-APPID
 # APPID 从 https://console.cloud.tencent.com/developer 获取
 COS_BUCKET=
 COS_REGION=ap-shanghai
 
-# ============ WS 推送 Bridge 配置 (SCF → TCS) ============
-# 跨实例推送密钥 (SCF 推送时认证用)
+# ============ WS 推送 Bridge 配置 (SCF → TCS) =============
+# 🔒 WS_PUSH_SECRET: SCF → WS 推送鉴权密钥
 # 必须与 TCS 容器环境变量 WS_PUSH_SECRET 一致
-# 生成方式: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# 生成: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 WS_PUSH_SECRET=
 
-# TCB 云托管 (TCS) 内网地址 — SCF 用此地址推送 WS 事件
-# 部署 TCS 后获取内网 IP/CLB: tcb cloudrun detail --service-name ecan-graphql-ws
+# 🟡 WS_TCS_URL: TCB 内网地址, 部署后由 bin/deploy-ws 自动写入
 # 格式: http://<内网IP>:9102
 WS_TCS_URL=
 
-# ============ CN 云任务调度 ============
+# ============ CN 云任务调度 ✅ =============
 TENCENT_SCHEDULER_FUNCTION=ecan-graphql-api
 TENCENT_SCF_NAMESPACE=default
 TENCENT_REGION=ap-shanghai
 
-# ============ 本地开发配置 ============
+# ============ 本地开发配置 ✅ =============
 NODE_ENV=production
 ALLOW_INSECURE_AUTH=false
+
+# 🔒 ECAN_JWT_SECRET: 30-day session token HS256 signing secret
+# 生成: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# 必须同时存在于 ecan-graphql-api 函数 和 ecan-graphql-ws 容器
+ECAN_JWT_SECRET=

--- a/cloudbase-graphql/resolvers/auth.js
+++ b/cloudbase-graphql/resolvers/auth.js
@@ -30,10 +30,25 @@ const { GraphQLError } = require('graphql');
 const { getTcbApp } = require('../tcb-init');
 
 const SESSION_TOKEN_TTL_DAYS = 30;
-const JWT_SECRET = process.env.ECAN_JWT_SECRET || process.env.JWT_SECRET || 'dev-secret-change-in-prod';
+// ECAN_JWT_SECRET: shared HS256 secret. Must match the value injected into
+// functions/ecan-graphql-ws/index.js (TCB EnvParams), otherwise the WS
+// container will reject every session token minted here.
+// Fallback to a non-secret sentinel so we fail loud at request time if the
+// env var is missing in production — instead of silently signing tokens with
+// a public string ('dev-secret-change-in-prod') that any attacker could use
+// to forge sessions. WS service uses the same defensive pattern.
+const JWT_SECRET = process.env.ECAN_JWT_SECRET || process.env.JWT_SECRET || null;
 
-/** Mint a custom JWT (no library needed — we only need exp + sub claims). */
+/** Mint a custom JWT (no library needed — we only need exp + sub claims).
+ *  Throws if JWT_SECRET is not configured — refusing to sign with a null key
+ *  is the whole point of removing the 'dev-secret-change-in-prod' fallback.
+ */
 function mintSessionToken(openid) {
+  if (!JWT_SECRET) {
+    throw new GraphQLError('ECAN_JWT_SECRET is not configured on this function', {
+      extensions: { code: 'INTERNAL_ERROR' },
+    });
+  }
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
   const now = Math.floor(Date.now() / 1000);
   const exp = now + SESSION_TOKEN_TTL_DAYS * 24 * 3600;
@@ -45,8 +60,12 @@ function mintSessionToken(openid) {
   return `${header}.${payload}.${sig}`;
 }
 
-/** Verify a session token and return its openid, or null. */
+/** Verify a session token and return its openid, or null.
+ *  Returns null when JWT_SECRET is unconfigured — caller treats this the
+ *  same as an invalid signature (no detail leaks about why).
+ */
 function verifySessionToken(token) {
+  if (!JWT_SECRET) return null;
   try {
     const parts = token.split('.');
     if (parts.length !== 3) return null;


### PR DESCRIPTION
Problem
-------
resolvers/auth.js fell back to the literal string
'dev-secret-change-in-prod' if ECAN_JWT_SECRET was missing from the SCF function EnvParams. That string is checked into git and is publicly known. In a misconfigured deploy where someone forgets to sync the secret, we would happily mint 30-day session tokens using a public string as the HMAC key — anyone could forge an admin session.

The WS container (functions/ecan-graphql-ws/index.js) already adopted the correct defensive pattern: JWT_SECRET = ... || null, plus an early-return in verifySessionToken. Mirror it here.

Changes
-------
resolvers/auth.js:
  - Replace 'dev-secret-change-in-prod' fallback with null.
  - mintSessionToken throws GraphQLError(INTERNAL_ERROR) when JWT_SECRET is null. This is the path that creates tokens, so refusing to sign is the right behaviour — silently signing with a garbage key would still let attackers forge sessions just by computing the HMAC themselves.
  - verifySessionToken returns null when JWT_SECRET is null, same as an invalid signature. Caller already treats null as "invalid session", so this is behaviour-preserving for callers.

.env.example, .env.local.example:
  - Add sensitivity labels (🔒 SECRET / 🟡 INTERNAL / ✅ PUBLIC) on every field so future contributors don't have to reverse- engineer which keys must stay out of git, screenshots, and public bug reports.
  - ECAN_JWT_SECRET was previously undocumented in .env.example despite being mandatory in production. Now it's there with a "must exist in BOTH api and ws container" note.

Not in this commit
------------------
- .env.local (still real values, still gitignored)
- The TCB_API_URL value with a double /api.tcloudbase.com/api/ segment in .env.local — pre-existing typo, not touched.