### PR TITLE
fix(auth): remove dead getClientCredential path; drop @cloudbase/node…

### DIFF
--- a/cloudbase-graphql/functions/ecan-graphql-ws/index.js
+++ b/cloudbase-graphql/functions/ecan-graphql-ws/index.js
@@ -50,14 +50,22 @@ const BUILD_VERSION = process.env.BUILD_VERSION || 'unknown';
 
 /** 解析 TCB JWT token → identity 对象。
  *
- * 支持三种 token 形式（按优先级）：
+ * 支持两种 token 形式（按优先级）：
  *   1. eCan 自签 30-day session token (HS256 JWT, `sub` = openid)
  *      — 优先支持。理由：桌面端 GraphQL 客户端在 access_token 过期后续
  *      发的就是 session token；如果不接受，整个 WS 连接 10 分钟必断。
  *   2. CloudBase access_token / wx JWT (10-min, `sub`/`openid`)
  *      — 首次扫码后、或 Intl/AWS 路径
- *   3. TCB 自定义登录票据 (legacy)
- *      — 旧 wx-open auth flow 残留
+ *
+ * 历史上还有第 3 路径: TCB 自定义登录票据 (`<id>/@@/<jwt>`) 通过
+ * `@cloudbase/node-sdk` 的 `auth.getClientCredential` 兜底 — 已删除。
+ * 原因: (a) `getClientCredential` 是 server-side OAuth client_credentials
+ *   flow, 用来拿 SDK 自己的 access key, **完全不验证传入的 token**;
+ *   SDK 源码 dist/auth/index.js:137-156 明确显示它忽略 `opts.token` 参数,
+ *   返回的是 server 凭据本身 (uid/openId 字段). 用它"验证用户 token"
+ *   等于完全没验证. (b) 所有客户端代码 (auth_manager.py / cloud_api.py /
+ *   endpoints.py / wan_chat.py) 都把 `/@@/` 格式拆成纯 JWT 再发, 所以这条
+ *   路径在生产永远不会被触发, 是 dead code.
  *
  * secret (``ECAN_JWT_SECRET`` / ``JWT_SECRET``) 必须和 resolvers/auth.js
  * 共用，否则客户端拿到的 session token 永远验不过。
@@ -147,25 +155,8 @@ async function resolveIdentity(token) {
     // JWT 解析失败，继续尝试其他方式
   }
 
-  // 方式3: TCB 自定义登录票据验证（用于微信登录等场景产生的票据）
-  try {
-    const CloudBase = require('@cloudbase/node-sdk');
-    const tcb = CloudBase.init({ envId: process.env.TCB_ENV_ID || process.env.SCF_NAMESPACE });
-    const auth = tcb.auth();
-    const userInfo = await Promise.race([
-      auth.getClientCredential({ token: rawToken }),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('getClientCredential timeout')), 5000)),
-    ]);
-    if (!userInfo) return null;
-    // TCB 返回字段名: uid / openId / userId，兼容所有
-    const uid = userInfo.uid || userInfo.openId || userInfo.openid || userInfo.userId;
-    if (!uid) return null;
-    return { userId: uid, raw: userInfo, source: 'tcb_client_credential' };
-  } catch (err) {
-    // 不使用 console.error — 容器 stdout 被 TCB 收集，console.log 可见
-    console.log('[auth] token verification failed:', err.message);
-    return null;
-  }
+  // 不再有第 3 路径 (TCB custom login ticket 兜底). 见上方 docstring 删除原因.
+  return null;
 }
 
 /** 提取认证 token: AppSync URL auth / Authorization header (兼容多种格式).

--- a/cloudbase-graphql/package-runtime.json
+++ b/cloudbase-graphql/package-runtime.json
@@ -4,7 +4,6 @@
   "description": "Minimal runtime dependencies for ecan-graphql-ws WebSocket server (TCB cloud container). Excludes SCF-only deps (@prisma/client, cos-nodejs-sdk-v5, graphql, graphql-yoga).",
   "private": true,
   "dependencies": {
-    "@cloudbase/node-sdk": "3.18.3",
     "ws": "8.18.0"
   },
   "engines": {

--- a/cloudbase-graphql/resolvers/auth.js
+++ b/cloudbase-graphql/resolvers/auth.js
@@ -27,7 +27,6 @@
 
 const crypto = require('crypto');
 const { GraphQLError } = require('graphql');
-const { getTcbApp } = require('../tcb-init');
 
 const SESSION_TOKEN_TTL_DAYS = 30;
 // ECAN_JWT_SECRET: shared HS256 secret. Must match the value injected into
@@ -122,34 +121,28 @@ function decodeOpenidFromJwt(token) {
 }
 
 /**
- * Check if a CloudBase access_token is still valid by calling getClientCredential.
- * Returns { valid: bool, accessToken: string, expiresIn: number }.
+ * Lightweight CloudBase access_token validity check.
+ *
+ * Returns { valid, accessToken, expiresIn } based purely on the local JWT
+ * `exp` claim. We DO NOT call @cloudbase/node-sdk's auth.getClientCredential
+ * because that API is the OAuth *client_credentials* flow — it returns the
+ * SDK's own access key (from its env-var credentials), not a verification of
+ * the supplied token. Source: node_modules/@cloudbase/node-sdk/dist/auth/
+ * index.js:137-156 explicitly ignores `opts.token` and posts to
+ * /auth/v1/token/clientCredential with grant_type=client_credentials. Using
+ * it to "verify a WeChat token" is a no-op masquerading as verification.
+ *
+ * CloudBase WeChat tokens cannot be revoked server-side — once we accept one
+ * it remains valid until its own `exp`. The caller (registerWeChatSession /
+ * refreshWeChatToken) treats `valid: false` as a hard error prompting the
+ * client to re-scan the QR code.
  */
-async function verifyWxAccessToken(accessToken) {
-  const tcbApp = getTcbApp();
-  if (!tcbApp) return { valid: false, accessToken: null, expiresIn: 0 };
-
-  // Decode exp locally first — fast path
+function verifyWxAccessToken(accessToken) {
   const exp = decodeJwtExp(accessToken);
   const now = Math.floor(Date.now() / 1000);
-  if (exp !== null && exp < now) {
-    return { valid: false, accessToken: null, expiresIn: 0 };
-  }
-
-  // Server-side verify via CloudBase
-  try {
-    const userInfo = await Promise.race([
-      tcbApp.auth().getClientCredential({ token: accessToken }),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('verify timeout')), 5000)
-      ),
-    ]);
-    if (!userInfo) return { valid: false, accessToken: null, expiresIn: 0 };
-    return { valid: true, accessToken, expiresIn: exp !== null ? Math.max(0, exp - now) : 600 };
-  } catch {
-    // Fallback: trust the local JWT exp
-    return { valid: exp !== null && exp > now, accessToken, expiresIn: exp !== null ? Math.max(0, exp - now) : 0 };
-  }
+  if (exp === null) return { valid: false, accessToken: null, expiresIn: 0 };
+  if (exp < now) return { valid: false, accessToken: null, expiresIn: 0 };
+  return { valid: true, accessToken, expiresIn: Math.max(0, exp - now) };
 }
 
 const Mutation = {


### PR DESCRIPTION
…-sdk from WS image

Background
----------
Both functions/ecan-graphql-ws/index.js (method 3) and resolvers/auth.js (verifyWxAccessToken) called `tcb.auth().getClientCredential({ token })` to "verify" user tokens. This was wrong on two levels.

1) The API does not verify anything. node_modules/@cloudbase/node-sdk/
   dist/auth/index.js:137-156 — `getClientCredential` is the OAuth
   *client_credentials* flow: it ignores `opts.token`, posts to
   /auth/v1/token/clientCredential with grant_type=client_credentials,
   and returns the SDK's *own* access key (derived from the env-var
   secretId/secretKey it was initialised with). The `uid`/`openId`
   fields on the response are server identity, not anything derived
   from the supplied token. Using it to "verify a WeChat access token"
   is a no-op that only verifies the SDK itself is still able to call
   TCB.

2) The path was unreachable in production. All client code
   (auth/auth_manager.py:2468, agent/cloud_api/cloud_api.py:1379,
   agent/cloud_api/endpoints.py:237, agent/chats/wan_chat.py:431)
   already strips the `<id>/@@/<jwt>` custom-login format down to
   the JWT part before sending. Only plain 3-segment JWTs reach the
   WS service, so method 3 in resolveIdentity never fires. Removing
   it changes no production behaviour.

Side effect of the bug
----------------------
In resolvers/auth.js, `verifyWxAccessToken` reported `valid: true` for any token whose `exp` claim was missing or unparseable, as long as the SDK itself could talk to TCB. So any forged / corrupted token without an exp claim got the green light from "Server-side verify via CloudBase". Replaced with a synchronous local-only check that returns `valid: false` whenever exp cannot be decoded.

Image size impact
-----------------
With @cloudbase/node-sdk pulled from package-runtime.json, the WS container no longer installs the SDK's 7MB @cloudbase scope plus ~27MB of transitive deps (core-js-pure 15M, xml2js 3.3M, bson 2.9M, @cloudbase/database etc.). Measured node_modules goes from 34MB to 184KB. Final container size drops from ~190MB to ~150MB. The docker-ignore continues to exclude resolvers/, scripts/, etc. so this is the only runtime-deps change needed.

Verified
--------
- node -c on both files passes.
- node scripts/test-units.js: full suite still PASS.
- /tmp/test-ws-auth.js: 8/8 resolveIdentity cases pass (HS256 valid/expired/wrong-sig, RS256 fallback, garbage, null).
- /tmp/test-auth-resolver.js: 5/5 verifyWxAccessToken cases pass, including the previously-buggy "no-exp claim" case.

Not changed
-----------
- cloudbase-graphql/package.json keeps @cloudbase/node-sdk — that manifest is for the SCF ecan-graphql-api function, which still uses it for GraphQL resolvers and Database access.