### PR TITLE
fix(ci): write OTA key to RUNNER_TEMP to escape persistent hardened-f…

### DIFF
--- a/.github/workflows/release-cn.yml
+++ b/.github/workflows/release-cn.yml
@@ -1145,39 +1145,29 @@ jobs:
           OTA_PRIVATE_KEY: ${{ secrets.OTA_ED25519_PRIVATE_KEY }}
         shell: powershell
         run: |
-          $keyDir = Join-Path $env:GITHUB_WORKSPACE 'build_system/certificates'
-          New-Item -ItemType Directory -Force -Path $keyDir | Out-Null
-          $keyPath = Join-Path $keyDir 'ed25519_private_key.pem'
-          # Decode secrets.OTA_ED25519_PRIVATE_KEY (base64 of the PEM blob)
-          # into build_system/certificates/ed25519_private_key.pem so
-          # sign_ota_artifacts() (called inside build.py prod) has the
-          # key on disk.
-          #
-          # Why no pre-delete and no ACL hardening:
-          #   Self-hosted runners reuse C:\actions-runner\_work\eCan.ai\eCan.ai
-          #   across runs, so the previous run's key file is still there.
-          #   The earlier hardening (SetAccessRuleProtection($true,$false) +
-          #   Allow Read for current user) was meant to lock the file to
-          #   build-agent Read only -- but it ALSO removed the inherited
-          #   Modify right that the next run needs to overwrite the file.
-          #   [System.IO.File]::WriteAllBytes() requires FILE_WRITE_DATA,
-          #   Remove-Item requires DELETE, and Set-Acl itself requires
-          #   WriteDAC. None of those are in the hardened "Read only" rule,
-          #   so every subsequent run failed with UnauthorizedAccessException
-          #   regardless of which deletion method was tried (cmd /c del,
-          #   takeown / icacls, all need admin that the runner lacks).
-          #
-          #   The default inherited ACL on a self-hosted runner's workspace
-          #   ("Authenticated Users: Modify" from C:\actions-runner\_work)
-          #   already grants the runner service account enough rights to
-          #   overwrite the file in place. We deliberately do NOT touch
-          #   the ACL here: hardening is defense-in-depth, and on a
-          #   single-tenant self-hosted runner it provides no meaningful
-          #   security gain while breaking subsequent runs.
+          # Write the OTA key to RUNNER_TEMP rather than
+          # build_system/certificates/. The latter lives under
+          # C:\actions-runner\_work\eCan.ai\eCan.ai\, which is the
+          # self-hosted runner's persistent workspace -- a previous
+          # run's ACL-hardened key file (Read-only ACE for the
+          # current user) blocks subsequent runs from overwriting
+          # the file via WriteAllBytes, Remove-Item, or Set-Acl,
+          # because none of those operations have the rights the
+          # hardened ACE grants. RUNNER_TEMP is per-job ephemeral,
+          # the directory does not exist before this step, so no
+          # stale hardened file can poison the new run.
+          $keyPath = Join-Path $env:RUNNER_TEMP 'ed25519_private_key.pem'
           [System.IO.File]::WriteAllBytes(
             $keyPath,
             [System.Convert]::FromBase64String($env:OTA_PRIVATE_KEY)
           )
+          # Export the path so the python signing step (which runs
+          # OTASigningManager.__init__ -> private_key_path) picks
+          # up the ephemeral location via OTA_PRIVATE_KEY_PATH.
+          # signing_manager.py honors that env var before falling
+          # back to build_system/certificates/.
+          "OTA_PRIVATE_KEY_PATH=$keyPath" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "[OK] OTA signing key installed at $keyPath"
 
       - name: Install Inno Setup

--- a/.github/workflows/release-intl.yml
+++ b/.github/workflows/release-intl.yml
@@ -766,39 +766,29 @@ jobs:
           OTA_PRIVATE_KEY: ${{ secrets.OTA_ED25519_PRIVATE_KEY }}
         shell: powershell
         run: |
-          $keyDir = Join-Path $env:GITHUB_WORKSPACE 'build_system/certificates'
-          New-Item -ItemType Directory -Force -Path $keyDir | Out-Null
-          $keyPath = Join-Path $keyDir 'ed25519_private_key.pem'
-          # Decode secrets.OTA_ED25519_PRIVATE_KEY (base64 of the PEM blob)
-          # into build_system/certificates/ed25519_private_key.pem so
-          # sign_ota_artifacts() (called inside build.py prod) has the
-          # key on disk.
-          #
-          # Why no pre-delete and no ACL hardening:
-          #   Self-hosted runners reuse C:\actions-runner\_work\eCan.ai\eCan.ai
-          #   across runs, so the previous run's key file is still there.
-          #   The earlier hardening (SetAccessRuleProtection($true,$false) +
-          #   Allow Read for current user) was meant to lock the file to
-          #   build-agent Read only -- but it ALSO removed the inherited
-          #   Modify right that the next run needs to overwrite the file.
-          #   [System.IO.File]::WriteAllBytes() requires FILE_WRITE_DATA,
-          #   Remove-Item requires DELETE, and Set-Acl itself requires
-          #   WriteDAC. None of those are in the hardened "Read only" rule,
-          #   so every subsequent run failed with UnauthorizedAccessException
-          #   regardless of which deletion method was tried (cmd /c del,
-          #   takeown / icacls, all need admin that the runner lacks).
-          #
-          #   The default inherited ACL on a self-hosted runner's workspace
-          #   ("Authenticated Users: Modify" from C:\actions-runner\_work)
-          #   already grants the runner service account enough rights to
-          #   overwrite the file in place. We deliberately do NOT touch
-          #   the ACL here: hardening is defense-in-depth, and on a
-          #   single-tenant self-hosted runner it provides no meaningful
-          #   security gain while breaking subsequent runs.
+          # Write the OTA key to RUNNER_TEMP rather than
+          # build_system/certificates/. The latter lives under
+          # C:\actions-runner\_work\eCan.ai\eCan.ai\, which is the
+          # self-hosted runner's persistent workspace -- a previous
+          # run's ACL-hardened key file (Read-only ACE for the
+          # current user) blocks subsequent runs from overwriting
+          # the file via WriteAllBytes, Remove-Item, or Set-Acl,
+          # because none of those operations have the rights the
+          # hardened ACE grants. RUNNER_TEMP is per-job ephemeral,
+          # the directory does not exist before this step, so no
+          # stale hardened file can poison the new run.
+          $keyPath = Join-Path $env:RUNNER_TEMP 'ed25519_private_key.pem'
           [System.IO.File]::WriteAllBytes(
             $keyPath,
             [System.Convert]::FromBase64String($env:OTA_PRIVATE_KEY)
           )
+          # Export the path so the python signing step (which runs
+          # OTASigningManager.__init__ -> private_key_path) picks
+          # up the ephemeral location via OTA_PRIVATE_KEY_PATH.
+          # signing_manager.py honors that env var before falling
+          # back to build_system/certificates/.
+          "OTA_PRIVATE_KEY_PATH=$keyPath" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "[OK] OTA signing key installed at $keyPath"
 
       - name: Install Inno Setup

--- a/build_system/signing_manager.py
+++ b/build_system/signing_manager.py
@@ -729,10 +729,24 @@ class SigningManager:
 
 class OTASigningManager:
     """OTA signing manager - using Ed25519 signing algorithm"""
-    
+
     def __init__(self, project_root: Path = None):
         self.project_root = project_root or Path.cwd()
-        self.private_key_path = self.project_root / "build_system" / "certificates" / "ed25519_private_key.pem"
+        # The key file path can be overridden via OTA_PRIVATE_KEY_PATH
+        # (used by GitHub Actions self-hosted runner workflows that
+        # write the key to a per-job ephemeral location under
+        # RUNNER_TEMP to avoid ACL hardening on persistent workspace
+        # paths). Falls back to the canonical project-root-relative
+        # location so existing local-dev and Linux CI usage still
+        # works without any environment setup.
+        override = os.environ.get('OTA_PRIVATE_KEY_PATH')
+        if override:
+            self.private_key_path = Path(override)
+        else:
+            self.private_key_path = (
+                self.project_root
+                / 'build_system' / 'certificates' / 'ed25519_private_key.pem'
+            )
         self.dist_dir = self.project_root / "dist"
     
     def sign_for_ota(self, version: str) -> bool:


### PR DESCRIPTION
…ile ACL

My previous fix (355f90c98) removed the in-job ACL hardening, but the file those earlier runs put under build_system/certificates/ed25519_private_key.pem is still sitting in C:\\actions-runner\\_work\\eCan.ai\\eCan.ai\\ with a Read-only ACE for the build agent -- and that hardened file is what blocks WriteAllBytes today. The Windows self-hosted runner does not have an admin escape hatch (no SeRestorePrivilege, no takeown-without-admin), so the file cannot be unlinked or modified from inside the runner account.

Avoid the persistent workspace entirely by writing the key to $RUNNER_TEMP\\ed25519_private_key.pem, which is per-job ephemeral and is cleaned by the runner between jobs. The python signing step picks up that location via a new OTA_PRIVATE_KEY_PATH env var (set through $GITHUB_ENV in the same workflow step), honored by OTASigningManager.__init__. The default build_system/certificates/... path is preserved as a fallback so local-dev and Linux CI are unaffected.

Applied to both release-cn.yml and release-intl.yml (Windows jobs only -- the macOS/Linux jobs run on filesystems without the NTFS ACL feature and are unaffected by the underlying bug).